### PR TITLE
[BUGFIX] Fixes accessing "options.Fluidcontent.sorting" property

### DIFF
--- a/Classes/Service/FluxService.php
+++ b/Classes/Service/FluxService.php
@@ -144,8 +144,8 @@ class FluxService implements SingletonInterface
     {
         $ascending = 'ASC' === strtoupper($sortDirection);
         uasort($objects, function ($a, $b) use ($sortBy, $ascending) {
-            $a = ObjectAccess::getProperty($a, $sortBy);
-            $b = ObjectAccess::getProperty($b, $sortBy);
+            $a = ObjectAccess::getPropertyPath($a, $sortBy);
+            $b = ObjectAccess::getPropertyPath($b, $sortBy);
             if ($a === $b) {
                 return 0;
             }


### PR DESCRIPTION
…idcontent)

The original error was: The property "options.Fluidcontent.sorting" on the subject was not accessible
(on Typo3 7.6.15 with Flux 8.0.0 and Fluidcontent 4.4.1)